### PR TITLE
Ported the "Add Custom Link" feature to Frontend using JavaScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,74 @@
+const addClinkBtn = document.querySelector("a.btn");
+let index = Number(addClinkBtn.dataset.index);
+addClinkBtn.addEventListener("click", (e) => {
+  index++;
+
+  /* The hierarchy of nodes/tags in the custom link fields HTML:
+  div (outer i.e., newClick)
+    label
+    div (row)
+      div1 (inner)
+        input (Name)
+        input (Icon)
+      div2 (inner)
+        input (Link/url)
+  */
+
+  // Creating the elements:
+  let newClink = document.createElement("div"); // div (outer)
+  newClink.className = "mb-3";
+
+  let label = document.createElement("label"); // label
+  label.className = "form-label";
+  label.appendChild(document.createTextNode(`Custom Link #${index - 4}`));
+
+  let row = document.createElement("div"); // div (row)
+  row.setAttribute("class", "row g-2");
+
+  let div1 = document.createElement("div"); // div1 (inner)
+  div1.setAttribute("class", "input-group col-sm");
+
+  const createField = (fieldName) => {
+    // function to create input fields
+    let field = document.createElement("input");
+
+    field.id = `links[${index}][${fieldName}]`;
+    field.name = `links[${index}][${fieldName}]`;
+    field.type = "text";
+    field.className = "form-control";
+
+    if (fieldName != "url") {
+      fieldName = fieldName.charAt(0).toUpperCase() + fieldName.slice(1);
+      field.placeholder = fieldName;
+      field.ariaPlaceholder = fieldName;
+    } else {
+      field.placeholder = "Link";
+      field.ariaPlaceholder = "Link";
+    }
+
+    return field;
+  };
+
+  let nameField = createField("name"); // input (Name)
+  let iconField = createField("icon"); // input (Icon)
+
+  let div2 = document.createElement("div"); // div2 (inner)
+  div2.setAttribute("class", "col-sm-7 col-md-8 col-xl-9");
+
+  let urlField = createField("url"); // input (Link/url)
+
+  // Creating the final component:
+  div2.appendChild(urlField);
+
+  div1.appendChild(nameField);
+  div1.appendChild(iconField);
+
+  row.appendChild(div1);
+  row.appendChild(div2);
+
+  newClink.appendChild(label);
+  newClink.appendChild(row);
+
+  let lastClink = document.querySelector(`form div:nth-child(${index + 5})`);
+  lastClink.after(newClink);
+});

--- a/index.php
+++ b/index.php
@@ -111,9 +111,10 @@ $lastsite_index = count($sites) - 1;
         </div>
         <button type="submit" class="btn btn-primary">Submit</button>
 <?php if ($num_clinks < 50) {?>
-        <a class="btn btn-secondary" href="?n=<?=$num_clinks + 1?>" role="button">Add Custom Link</a>
+        <a class="btn btn-secondary" data-index="<?=($lastsite_index + $num_clinks)?>" role="button">Add Custom Link</a>
 <?php }?>
       </form>
     </div>
+    <script src="./index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
I wrote all of the JavaScript code in an `index.js` file.
First, I removed the backend dependency of the `Add Custom Link` button.

Then, I added a `data-index` attribute to get the number of link fields when the page first loads, using the variables: `lastsite_index` and `num_clinks`. I stored this value inside a global variable called `index`, which I assumed to be beginning from 0. It was just to make sure if any changes were made to the number of link fields in the future.

After this, I created an event listener for the `Add Custom Link` button with code that allows it to add an extra custom field. And, I used a little arithmetic with the `index` variable to calculate the Custom Link number.

Finally, at the end, I used a little math again to calculate the position of the last custom link component and place the new custom link component after it.

I tested the whole thing locally on my laptop, and the PHP backend was able to handle these extra fields created entirely in the frontend. The resulting output had all the extra links I gave it. Here's the preview output:

<img width="596" alt="image" src="https://github.com/chriskthomas/linkfree-generator/assets/103265133/b07ab50d-aa08-4b07-9260-88098424d1f3"><br/>
(I didn't provide any icons)