### PR TITLE
Add blur event to append the protocol if missing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,7 @@ function loadFormFromLocalStorage() {
  */
 function addProtocolIfMissing(input) {
   let url = input.value.trim();
-  if (url !== "" && !/^https?:\/\//i.test(url)) {
+  if (url !== "" && !/:/.test(url)) {
     input.value = "http://" + url;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -157,6 +157,22 @@ function loadFormFromLocalStorage() {
   }
 }
 
+/**
+ * Adds the protocol 'http://' to a URL input value if it's missing.
+ *
+ * @param {HTMLInputElement} input - The URL input element.
+ * @returns {void}
+ * @example
+ * const inputElement = document.getElementById('url');
+ * addProtocolIfMissing(inputElement);
+ */
+function addProtocolIfMissing(input) {
+  let url = input.value.trim();
+  if (url !== "" && !/^https?:\/\//i.test(url)) {
+    input.value = "http://" + url;
+  }
+}
+
 // Event listeners
 
 addCustomLinkButton.addEventListener("click", () => {
@@ -176,4 +192,11 @@ form.addEventListener("submit", (e) => {
 
 document.addEventListener("DOMContentLoaded", () => {
   loadFormFromLocalStorage();
+});
+
+let urlInputs = document.querySelectorAll('input[type="url"]');
+urlInputs.forEach((input) => {
+  input.addEventListener("blur", (event) => {
+    addProtocolIfMissing(event.target);
+  });
 });


### PR DESCRIPTION
Wasnt sure if the line (197) declaring the variable for url input fields belong with the event listeners but it made more sense to put it there than with the function? 

Other than that the  `addProtocolIfMissing` function successfully appends the protocol if it does not detect one.